### PR TITLE
Update the result post of Fighting the random curse with "with Goldener"

### DIFF
--- a/results/FIGHTING_RANDOM_SPLIT_CURSE.md
+++ b/results/FIGHTING_RANDOM_SPLIT_CURSE.md
@@ -1,4 +1,4 @@
-# FIGHTING THE RANDOM CURSE <br> Train/Val split on CIFAR 10, PASCAL VOC and IMDB
+# FIGHTING THE RANDOM CURSE WITH GOLDENER <br> Train/Val split on CIFAR 10, PASCAL VOC and IMDB
 
 [**Context**](#1-context) |
 [**Experiments**](#2-experiments) |


### PR DESCRIPTION
This pull request makes a small change to the title in the `results/FIGHTING_RANDOM_SPLIT_CURSE.md` file to include "WITH GOLDENER". This clarifies that the results or discussion are specifically related to the "GOLDENER" method or tool.