### PR TITLE
Pin lightning version to 2.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 
 dependencies = [
     "torch",
-    "lightning==2.6.1", # https://github.com/Lightning-AI/pytorch-lightning/security/advisories/GHSA-w37p-236h-pfx3
+    "lightning<=2.6.1", # https://github.com/Lightning-AI/pytorch-lightning/security/advisories/GHSA-w37p-236h-pfx3
     "mlflow",
     "goldener",
     "scikit-learn",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 
 dependencies = [
     "torch",
-    "lightning",
+    "lightning==2.6.1", # https://github.com/Lightning-AI/pytorch-lightning/security/advisories/GHSA-w37p-236h-pfx3
     "mlflow",
     "goldener",
     "scikit-learn",

--- a/uv.lock
+++ b/uv.lock
@@ -1669,7 +1669,7 @@ requires-dist = [
     { name = "goldener" },
     { name = "hydra-core" },
     { name = "iterative-stratification" },
-    { name = "lightning", specifier = "==2.6.1" },
+    { name = "lightning", specifier = "<=2.6.1" },
     { name = "matplotlib", marker = "extra == 'reports'" },
     { name = "mlflow" },
     { name = "notebook", marker = "extra == 'reports'" },

--- a/uv.lock
+++ b/uv.lock
@@ -1669,7 +1669,7 @@ requires-dist = [
     { name = "goldener" },
     { name = "hydra-core" },
     { name = "iterative-stratification" },
-    { name = "lightning" },
+    { name = "lightning", specifier = "==2.6.1" },
     { name = "matplotlib", marker = "extra == 'reports'" },
     { name = "mlflow" },
     { name = "notebook", marker = "extra == 'reports'" },


### PR DESCRIPTION
This pull request makes a targeted dependency update to address a security advisory. The version of `lightning` is now pinned to `2.6.1` in the `pyproject.toml` file to ensure the project uses a secure version.

Dependency management:

* Pinned the `lightning` dependency to version `2.6.1` in `pyproject.toml` to address a security advisory (GHSA-w37p-236h-pfx3).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap `lightning` at `<=2.6.1` to mitigate GHSA-w37p-236h-pfx3 and keep installs on a patched version.

- **Dependencies**
  - Set `lightning<=2.6.1` in `pyproject.toml` and `uv.lock`.

<sup>Written for commit 4304f4c6b74c9a3508915c50cdf7af8dafa22369. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

